### PR TITLE
Use pyqt baseapp

### DIFF
--- a/fs-uae-install.patch
+++ b/fs-uae-install.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.am b/Makefile.am
+index 2d9a86c..7a2b2fe 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1419,7 +1419,7 @@ install-data-hook: mo fs-uae.dat
+ 	mkdir -p $(DESTDIR)$(datadir)/icons
+ 	cp -R $(s)/share/icons/* $(DESTDIR)$(datadir)/icons
+ 	mkdir -p $(DESTDIR)$(datadir)/locale
+-	cp -R $(b)/share/locale/* $(DESTDIR)$(datadir)/locale
++#       cp -R $(b)/share/locale/* $(DESTDIR)$(datadir)/locale
+ 	mkdir -p $(DESTDIR)$(datadir)/mime
+ 	cp -R $(s)/share/mime/* $(DESTDIR)$(datadir)/mime
+ 

--- a/net.fsuae.FS-UAE.appdata.xml
+++ b/net.fsuae.FS-UAE.appdata.xml
@@ -7,7 +7,6 @@
   <developer_name>Frode Solheim</developer_name>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
-  <translation/>
   <description>
     <p>
       FS-UAE is an Amiga emulator for Windows, Linux and Mac OS X based on
@@ -22,46 +21,62 @@
     </p>
   </description>
   <screenshots>
-    <screenshot type="default">https://fs-uae.net/images/fs-uae/front4.png</screenshot>
-    <screenshot>https://fs-uae.net/images/fs-uae/front1.png</screenshot>
-    <screenshot>https://fs-uae.net/images/fs-uae/front2.png</screenshot>
-    <screenshot>https://fs-uae.net/images/fs-uae/front3.png</screenshot>
-    <screenshot>https://fs-uae.net/images/fs-uae/front5.png</screenshot>
+    <screenshot type="default">
+      <image>https://fs-uae.net/images/fs-uae/front4.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://fs-uae.net/images/fs-uae/front1.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://fs-uae.net/images/fs-uae/front2.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://fs-uae.net/images/fs-uae/front3.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://fs-uae.net/images/fs-uae/front5.png</image>
+    </screenshot>
   </screenshots>
   <url type="homepage">https://fs-uae.net/</url>
   <url type="bugtracker">https://github.com/FrodeSolheim/fs-uae/issues</url>
   <content_rating type="oars-1.1"/>
   <releases>
     <release date="2022-06-22" version="3.1.66">
-      <ul>
-        <li>It is a minor maintenance release of the 3.1.x series (and possibly the last one).</li>
-        <li>The bundled SDL version has been updated to 2.0.18, and updated controller mappings are also included.</li>
-      </ul>
+      <description>
+        <ul>
+          <li>It is a minor maintenance release of the 3.1.x series (and possibly the last one).</li>
+          <li>The bundled SDL version has been updated to 2.0.18, and updated controller mappings are also included.</li>
+        </ul>
+      </description>
     </release>
     <release date="2021-11-10" version="3.1.0">
-      <ul>
-        <li>Fix device helper for xinput devices with recent SDL2 versions.</li>
-        <li>Support for multiple mice disabled by default on macOS due to security warning. Use option multiple_mice = 1 to enable.</li>
-        <li>Disable expect_version option (no longer synchronized with launcher).</li>
-        <li>Added support for more physical keys (when using rawinput).</li>
-        <li>Compilation fixes for Apple M1 hardware.</li>
-        <li>Netplay desync fixes related to file system (directory hard drives).</li>
-        <li>Better virtual memory reservation algorithm.</li>
-        <li>Option to automatically pause on menu screen [mrsilver76].</li>
-        <li>Use RTLD_DEEPBIND with dlopen on Linux when loading plugins.</li>
-        <li>Changes to how plugins are looked up.</li>
-        <li>Ide patch.</li>
-        <li>SCP floppy image doesn't wrap to revolution #0 cleanly [keirf].</li>
-        <li>Fixed crash in nname_to_aname [PowderedToastMan].</li>
-      </ul>
+      <description>
+        <ul>
+          <li>Fix device helper for xinput devices with recent SDL2 versions.</li>
+          <li>Support for multiple mice disabled by default on macOS due to security warning. Use option multiple_mice = 1 to enable.</li>
+          <li>Disable expect_version option (no longer synchronized with launcher).</li>
+          <li>Added support for more physical keys (when using rawinput).</li>
+          <li>Compilation fixes for Apple M1 hardware.</li>
+          <li>Netplay desync fixes related to file system (directory hard drives).</li>
+          <li>Better virtual memory reservation algorithm.</li>
+          <li>Option to automatically pause on menu screen [mrsilver76].</li>
+          <li>Use RTLD_DEEPBIND with dlopen on Linux when loading plugins.</li>
+          <li>Changes to how plugins are looked up.</li>
+          <li>Ide patch.</li>
+          <li>SCP floppy image doesn't wrap to revolution #0 cleanly [keirf].</li>
+          <li>Fixed crash in nname_to_aname [PowderedToastMan].</li>
+        </ul>
+      </description>
     </release>
     <release date="2020-04-24" version="3.0.5" />
     <release date="2020-04-23" version="3.0.4">
-      <ul>
-        <li>Fix compilation of sana2.cpp with GCC 10.</li>
-        <li>Fix OpenGL shaders with multiple passes on macOS.</li>
-        <li>Updated the GLAD OpenGL loader.</li>
-      </ul>
+      <description>
+        <ul>
+          <li>Fix compilation of sana2.cpp with GCC 10.</li>
+          <li>Fix OpenGL shaders with multiple passes on macOS.</li>
+          <li>Updated the GLAD OpenGL loader.</li>
+        </ul>
+      </description>
     </release>
     <release date="2020-03-09" version="3.0.3">
       <description>

--- a/net.fsuae.FS-UAE.yml
+++ b/net.fsuae.FS-UAE.yml
@@ -2,9 +2,17 @@ app-id: net.fsuae.FS-UAE
 branch: stable
 command: fs-uae
 runtime: org.kde.Platform
-runtime-version: '5.15-22.08'
+runtime-version: '5.15-24.08'
 sdk: org.kde.Sdk
+base: com.riverbankcomputing.PyQt.BaseApp
+base-version: '5.15-24.08'
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+build-options:
+  env:
+    - BASEAPP_REMOVE_WEBENGINE=1
 rename-desktop-file: fs-uae.desktop
+rename-mime-file: fs-uae.xml
 rename-icon: fs-uae
 finish-args:
   - --device=all
@@ -14,75 +22,6 @@ finish-args:
   - --socket=pulseaudio
   - --socket=x11
 modules:
-  - name: sip
-    buildsystem: simple
-    build-commands:
-      - python3 configure.py
-        --bindir=/app/bin
-        --destdir=/app/lib/python3.10/site-packages
-        --incdir=/app/include/python3
-        --sipdir=/app/share/sip
-        --stubsdir=/app/lib/python3.10/site-packages
-        --sip-module=PyQt5.sip
-      - make -j $FLATPAK_BUILDER_N_JOBS
-      - make install
-    cleanup:
-      - /bin
-      - /include
-      - /lib/python3.10/site-packages/*.pyi
-    sources:
-      - type: archive
-        url: https://www.riverbankcomputing.com/static/Downloads/sip/4.19.25/sip-4.19.25.tar.gz
-        sha256: b39d93e937647807bac23579edbff25fe46d16213f708370072574ab1f1b4211
-
-  - name: pyqt
-    buildsystem: simple
-    build-commands:
-      - python3 configure.py
-        --confirm-license
-        --bindir=/app/bin
-        --destdir=/app/lib/python3.10/site-packages
-        --sip-incdir=/app/include/python3
-        --sipdir=/app/share/sip
-        --stubsdir=/app/lib/python3.10/site-packages
-        --no-docstrings 
-        --no-qml-plugin 
-        --no-qsci-api 
-        --no-sip-files 
-        --no-tools 
-        --disable=QtBluetooth 
-        --disable=QtDesigner 
-        --disable=QtLocation 
-        --disable=QtMultimedia 
-        --disable=QtMultimediaWidgets 
-        --disable=QtNfc 
-        --disable=QtPositioning
-        --disable=QtQml 
-        --disable=QtQuick 
-        --disable=QtQuickWidgets 
-        --disable=QtSensors 
-        --disable=QtSql 
-        --disable=QtTest 
-        --disable=QtWebChannel 
-        --disable=QtWebEngine 
-        --disable=QtWebEngineCore 
-        --disable=QtWebKit 
-        --disable=QtWebKitWidgets 
-        --disable=QtXmlPatterns 
-        --disable=QWebEngineWidgets         
-      - make -j $FLATPAK_BUILDER_N_JOBS
-      - make install
-    config-opts:
-      - --disable-static
-      - --enable-x11
-    cleanup:
-      - /include
-      - /lib/python3.10/site-packages/*.pyi
-    sources:
-      - type: archive
-        url: https://files.pythonhosted.org/packages/8e/a4/d5e4bf99dd50134c88b95e926d7b81aad2473b47fde5e3e4eac2c69a8942/PyQt5-5.15.4.tar.gz
-        sha256: 2a69597e0dd11caabe75fae133feca66387819fc9bc050f547e5551bce97e5be
-
   - name: libmpeg2
     config-opts:
       - --disable-static
@@ -103,15 +42,14 @@ modules:
           - autoreconf -vfi
 
   - name: fs-uae
-    skip-arches:
-      - i386
-      - x86_64
-    config-opts:
-      - --disable-jit
+    build-options:
+      arch:
+        aarch64:
+          config-opts:
+            - --disable-jit
     no-autogen: true
     post-install:
-      - sed -i s/NoDisplay=.*/NoDisplay=false/ /app/share/applications/fs-uae.desktop
-      - cp /app/share/mime/packages/fs-uae.xml /app/share/mime/packages/${FLATPAK_ID}.xml
+      - desktop-file-edit --set-key=NoDisplay --set-value=false /app/share/applications/fs-uae.desktop
     cleanup:
       - /share/man
       - /share/doc
@@ -119,22 +57,11 @@ modules:
       - type: archive
         url: https://fs-uae.net/files/FS-UAE/Stable/3.1.66/fs-uae-3.1.66.tar.xz
         sha256: 606e1868b500413d69bd33bb469f8fd08d6c08988801f17b7dd022f3fbe23832
-
-  - name: fs-uae-jit
-    only-arches:
-      - i386
-      - x86_64
-    no-autogen: true
-    post-install:
-      - sed -i s/NoDisplay=.*/NoDisplay=false/ /app/share/applications/fs-uae.desktop
-      - cp /app/share/mime/packages/fs-uae.xml /app/share/mime/packages/${FLATPAK_ID}.xml
-    cleanup:
-      - /share/man
-      - /share/doc
-    sources:
-      - type: archive
-        url: https://fs-uae.net/files/FS-UAE/Stable/3.1.66/fs-uae-3.1.66.tar.xz
-        sha256: 606e1868b500413d69bd33bb469f8fd08d6c08988801f17b7dd022f3fbe23832
+      - type: patch
+        path: fs-uae-install.patch
+      - type: shell
+        commands:
+          - autoreconf -vfi
 
   - name: fs-uae-launcher
     make-install-args:
@@ -145,11 +72,14 @@ modules:
       - mv /app/share/applications/fs-uae-launcher.desktop /app/share/applications/${FLATPAK_ID}.Launcher.desktop
       - mv /app/share/icons/hicolor/64x64/apps/fs-uae-launcher.png /app/share/icons/hicolor/64x64/apps/${FLATPAK_ID}.Launcher.png
       - mv /app/share/icons/hicolor/128x128/apps/fs-uae-launcher.png /app/share/icons/hicolor/128x128/apps/${FLATPAK_ID}.Launcher.png
-      - sed -i s/Icon=.*/Icon=net.fsuae.FS-UAE.Launcher/ /app/share/applications/${FLATPAK_ID}.Launcher.desktop
+      - desktop-file-edit --set-icon=net.fsuae.FS-UAE.Launcher /app/share/applications/${FLATPAK_ID}.Launcher.desktop
+      - install -D -m644 -t /app/share/appdata/ ${FLATPAK_ID}.appdata.xml
     sources:
       - type: archive
         url: https://fs-uae.net/files/FS-UAE-Launcher/Stable/3.1.66/fs-uae-launcher-3.1.66.tar.xz
         sha256: 47f09069e5b474c0295e989e13edef0eb76c5982fdefd96ec62e0b5363a08ebe
+      - type: file
+        path: net.fsuae.FS-UAE.appdata.xml
       - type: shell
         commands:
           - sed 's/prefix := .*/prefix := /g' -i ./Makefile
@@ -208,12 +138,3 @@ modules:
           - type: archive
             url: https://github.com/kjd/idna/archive/v2.8.tar.gz
             sha256: db438aeba52c606cf1dd9671cb746377b4baeaea923397152e91576e8404d87a
-
-  - name: appdata
-    buildsystem: simple
-    build-commands:
-      - mkdir -p /app/share/appdata
-      - install -D -m644 -t /app/share/appdata/ ${FLATPAK_ID}.appdata.xml
-    sources:
-      - type: file
-        path: net.fsuae.FS-UAE.appdata.xml


### PR DESCRIPTION
Fix the appstream file
Fix the build

Using the PyQt baseapp simplify the build and make it easier to maintainer.
23.08 for now

Close #20
Close #22 